### PR TITLE
Two way Relationship data tests and fixed broken data

### DIFF
--- a/data/autotech.json
+++ b/data/autotech.json
@@ -1,7 +1,7 @@
 [
   {
     "name": "Volkswagen Group",
-    "founded": ["VW Innovation Fund", "Volkswagen Digital Lab", "Volkswagen Data Lab", " Volkswagen Mobility Lab", "Volkswagen Electronic Research Lab", "MOIA", "CyMotive Technologies"],
+    "founded": ["VW Innovation Fund", "Volkswagen Digital Lab", "Volkswagen Data Lab", "Volkswagen Mobility Lab", "Volkswagen Electronic Research Lab", "MOIA", "CyMotive Technologies"],
     "mentors": ["Anacode", "DocRAID", "Edisonweb", "Liftago", "Re2You", "Just Charge", "Plugsurfing", "gigaaa"],
     "investedIn": ["Gett", "QuantumScape", "Navistar"],
     "acquired": ["SEAT", "ŠKODA", "Bentley", "Bugatti", "Scania", "MAN", "Audi", "Porsche"],
@@ -599,19 +599,19 @@
   },
   {
     "name": "CelLink",
-    "foundedBy": ["Robert Bosch Venture Capital"]
+    "investedBy": ["Robert Bosch Venture Capital"]
   },
   {
     "name": "Chronocam",
-    "foundedBy": ["Robert Bosch Venture Capital"]
+    "investedBy": ["Robert Bosch Venture Capital"]
   },
   {
     "name": "Aethon",
-    "foundedBy": ["Robert Bosch Venture Capital"]
+    "investedBy": ["Robert Bosch Venture Capital"]
   },
   {
     "name": "AImotive",
-    "foundedBy": ["Robert Bosch Venture Capital"]
+    "investedBy": ["Robert Bosch Venture Capital"]
   },
   {
     "name": "Robert Bosch Start-up",
@@ -633,7 +633,7 @@
   },
   {
     "name": "Continental Automotive Systems",
-    "acquiredBy": ["Continental"]
+    "foundedBy": ["Continental"]
   },
   {
     "name": "ContiTech",

--- a/test/data.js
+++ b/test/data.js
@@ -1,17 +1,17 @@
-var assert = require('assert');
-var companies = require('../data/autotech.json');
+const assert = require('assert');
+const companies = require('../data/autotech.json');
 
 describe('#Data Purity', () => {
-  it('Check for duplicate data', function() {
-    var companyNames = companies.map(company => company.name);
-    var uniqueCompanyNames = [...new Set(companyNames)];
+  it('No duplicate data', function() {
+    let companyNames = companies.map(company => company.name);
+    let uniqueCompanyNames = [...new Set(companyNames)];
     assert.equal(companyNames.length, uniqueCompanyNames.length);
   });
 
-  it('Check for missing company data', function() {
-    var companyNames = companies.map(company => company.name);
-    var relationships = ["mentoredBy", "foundedBy", "investedBy", "acquiredBy", "partneredWith", "mentors", "founded", "investedIn", "acquired"];
-    var linkedCompanies = companies.reduce((nameList, company) => {
+  it('No missing company data', function() {
+    let companyNames = companies.map(company => company.name);
+    let relationships = ["mentoredBy", "foundedBy", "investedBy", "acquiredBy", "partneredWith", "mentors", "founded", "investedIn", "acquired"];
+    let linkedCompanies = companies.reduce((nameList, company) => {
       relationships.forEach(rel => {
         if (company[rel]) {
           company[rel].forEach(linkedCompany => {
@@ -25,5 +25,39 @@ describe('#Data Purity', () => {
     }, []);
     
     assert.equal(companyNames.length, linkedCompanies.length);
+  });
+
+  it('All relationships are two way', function() {
+    const mapping = {
+      "mentoredBy": "mentors",
+      "foundedBy": "founded",
+      "investedBy": "investedIn",
+      "acquiredBy": "acquired",
+      "partneredWith": "partneredWith",
+      "mentors": "mentoredBy",
+      "founded": "foundedBy",
+      "investedIn": "investedBy",
+      "acquired": "acquiredBy"
+    };
+
+    const companiesHash = companies.reduce((acc, curr) => {
+      acc[curr.name] = curr;
+      return acc;
+    }, {});
+
+    companies.forEach(company => {
+      let relationshipKeys = Object.keys(company).filter(key => key !== "name");
+
+      relationshipKeys.forEach(relationship => {
+        company[relationship].forEach(relatedCompany => {
+          let relatedCompanyData = companiesHash[relatedCompany];
+          let reverseRelationship = mapping[relationship];
+
+          assert.ok(relatedCompanyData, `${relatedCompany} is either missing or it's name misspelt`)
+          assert.ok(relatedCompanyData[reverseRelationship], `Relationship is broken btn ${relatedCompany} and ${company.name}`);
+          assert.ok(relatedCompanyData[reverseRelationship].includes(company.name), `Relationship is broken btn ${relatedCompany} and ${company.name}`);
+        })
+      });
+    });
   });
 });


### PR DESCRIPTION
- Added tests to double check that relationships btn companies are both ways.
- if `A` invests in `B` & `C`, it checks whether `B` & `C` have `A` listed as investor
- Fixed broken data the tests uncovered

- [x] https://github.com/honeypotio/honeypot/issues/922