### PR TITLE
Reinstating Autotechmap

### DIFF
--- a/CNAME
+++ b/CNAME
@@ -1,2 +1,1 @@
-autotechwheel.honeypot.io
 autotechmap.honeypot.io


### PR DESCRIPTION
- Going back due to faulty redirects for autotechmap.honeypot.io