### PR TITLE
Make travis run tests for gh-pages also

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,7 @@
 language: node_js
 node_js:
     - 6.9.5
+branches:
+  only:
+    - gh-pages
+    - /.*/


### PR DESCRIPTION
Travis currently ignores running tests on the main branch (i.e: `gh-pages`). We fixed this here. For more info: https://docs.travis-ci.com/user/customizing-the-build/#Safelisting-or-blocklisting-branches